### PR TITLE
HHVM fix in Whoops - flush before exit

### DIFF
--- a/Services/Exceptions/lib/Whoops/Run.php
+++ b/Services/Exceptions/lib/Whoops/Run.php
@@ -285,6 +285,7 @@ class Run
         }
 
         if ($willQuit) {
+            flush(); // HHVM fix for https://github.com/facebook/hhvm/issues/4055
             exit(1);
         }
 


### PR DESCRIPTION
Also suggested as pull-request upstream https://github.com/colin-kiegel/whoops/pull/1
