### PR TITLE
Trunk phpunit

### DIFF
--- a/Services/Administration/test/ilSettingTest.php
+++ b/Services/Administration/test/ilSettingTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilSettingTest
+ * @group needsInstalledILIAS 
+ */
 class ilSettingTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/Authentication/test/ilSessionTest.php
+++ b/Services/Authentication/test/ilSessionTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilSessionTest
+ * @group needsInstalledILIAS
+ */
 class ilSessionTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/Cache/test/ilCacheTest.php
+++ b/Services/Cache/test/ilCacheTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilCacheTest extends PHPUnit_Framework_TestCase

--- a/Services/Database/test/Basic/ilDatabaseBaseTest.php
+++ b/Services/Database/test/Basic/ilDatabaseBaseTest.php
@@ -25,7 +25,9 @@
 
 /**
  * TestCase for the ilDatabaseCommonTest
- *
+ * 
+ * @group needsInstalledILIAS
+ *        
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2InnodbTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2InnodbTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2InnodbTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2MyISAMTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2MyISAMTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2MyISAMTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2PostgresTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2PostgresTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2PostgresTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Init/test/ilInitialisationTest.php
+++ b/Services/Init/test/ilInitialisationTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * TestCase for the ilContext
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  */
 class ilInitialisationTest extends PHPUnit_Framework_TestCase {

--- a/Services/MetaData/test/ilMDTest.php
+++ b/Services/MetaData/test/ilMDTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilMDTest extends PHPUnit_Framework_TestCase

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -37,7 +37,7 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 		
 		// scan Modules and Services directories
 		$basedirs = array("Services", "Modules");
-		
+
 		foreach ($basedirs as $basedir)
 		{
 			// read current directory

--- a/Services/Tree/test/ilTreeTest.php
+++ b/Services/Tree/test/ilTreeTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilTreeTest extends PHPUnit_Framework_TestCase

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -48,7 +48,7 @@ class ilTemplateTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testilTemplateGet()
 	{
-		require_once 'HTML/Template/ITX.php';
+		#require_once 'HTML/Template/ITX.php';
 		include_once("./Services/UICore/classes/class.ilTemplateHTMLITX.php");
 		include_once("./Services/UICore/classes/class.ilTemplate.php");
 		$tpl = new ilTemplate("tpl.test_template_1.html", true, true, "Services/UICore/test");

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -7,7 +7,7 @@
  * @author Alex Killing <killing@leifos.de>
  *
  * @version $Id$
- *
+ * @group needsInstalledILIAS
  * @ingroup ServicesUICore
  */
 class ilTemplateTest extends PHPUnit_Framework_TestCase

--- a/Services/User/test/ilObjUserTest.php
+++ b/Services/User/test/ilObjUserTest.php
@@ -1,6 +1,10 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+/**
+ * Class ilObjUserTest
+ * @group needsInstalledILIAS
+ */
 class ilObjUserTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/XHTMLPage/test/ilXHTMLPageTest.php
+++ b/Services/XHTMLPage/test/ilXHTMLPageTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilXHTMLPageTest
+ * @group needsInstalledILIAS 
+ */
 class ilXHTMLPageTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;


### PR DESCRIPTION
Added all test suites to group which throws warning about missing "cfg.phpunit.php", should now be all. CI Server is now able to produce results again.
